### PR TITLE
fix: update Docker image tags to use 'latest' for default branch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image tagging logic to apply the "latest" tag exclusively to the default branch, while maintaining existing tags for pull requests, semantic versioning patterns, and commit SHA references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->